### PR TITLE
Don't handle a missing storage file error when reading

### DIFF
--- a/toodoo/todolist.go
+++ b/toodoo/todolist.go
@@ -52,13 +52,11 @@ func newTodo(name string) *Todo {
 
 func (todos *TodoList) Read() {
 	file, err := ioutil.ReadFile(saveFileLocation())
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	json_err := json.Unmarshal(file, todos)
-	if json_err != nil {
-		log.Fatal(json_err)
+	if err == nil {
+		json_err := json.Unmarshal(file, todos)
+		if json_err != nil {
+			log.Fatal(json_err)
+		}
 	}
 }
 


### PR DESCRIPTION
When you first install toodoo, you don't necessarily have a storage file
in ~/.toodoos.json which was originally causing an error.

Fact is, if this file doesn't exist, it doesn't matter, as the process
of adding a todo will create this file for you.

This fixes #13 
