### PR TITLE
Allow multiple toodoo lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Toodoo
+
+A simple command line application to store todos
+
+## Commands
+
+```shell
+list
+add
+complete
+incomplete
+remove
+```
+
+## Options
+
+`--list="listname"` - Defaults to "default"

--- a/main.go
+++ b/main.go
@@ -11,23 +11,24 @@ import (
 )
 
 func main() {
+	listName := flag.String("list", "default", "The todo list that you want to manipulate")
 	flag.Parse()
 
 	cmd := flag.Arg(0)
 
 	switch cmd {
 	case "list":
-		list()
+		list(*listName)
 	case "add":
 		arguments := flag.Args()[1:]
 		name := strings.Join(arguments, " ")
-		add(name)
+		add(*listName, name)
 	case "remove":
 		index, err := strconv.ParseInt(flag.Arg(1), 10, 0)
 		if err != nil {
 			panic(err)
 		}
-		remove(index)
+		remove(*listName, index)
 	case "help":
 		usage()
 	case "complete":
@@ -35,20 +36,20 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		complete(index)
+		complete(*listName, index)
 	case "incomplete":
 		index, err := strconv.ParseInt(flag.Arg(1), 10, 0)
 		if err != nil {
 			panic(err)
 		}
-		incomplete(index)
+		incomplete(*listName, index)
 	case "":
 		usage()
 		os.Exit(1)
 	default:
 		arguments := flag.Args()[0:]
 		name := strings.Join(arguments, " ")
-		add(name)
+		add(*listName, name)
 	}
 }
 
@@ -70,35 +71,45 @@ The commands are:
 	version         print the version number`)
 }
 
-func list() {
-	todos := toodoo.TodoList{}
+func list(listName string) {
+	todos := toodoo.TodoList{
+		Name: listName,
+	}
 	todos.Read()
 	todos.List()
 }
 
-func add(name string) {
-	todos := toodoo.TodoList{}
+func add(listName string, name string) {
+	todos := toodoo.TodoList{
+		Name: listName,
+	}
 	todos.Read()
 	todos.Add(name)
 	todos.Save()
 }
 
-func remove(index int64) {
-	todos := toodoo.TodoList{}
+func remove(listName string, index int64) {
+	todos := toodoo.TodoList{
+		Name: listName,
+	}
 	todos.Read()
 	todos.Remove(index)
 	todos.Save()
 }
 
-func complete(index int64) {
-	todos := toodoo.TodoList{}
+func complete(listName string, index int64) {
+	todos := toodoo.TodoList{
+		Name: listName,
+	}
 	todos.Read()
 	todos.Find(index).MarkAsComplete()
 	todos.Save()
 }
 
-func incomplete(index int64) {
-	todos := toodoo.TodoList{}
+func incomplete(listName string, index int64) {
+	todos := toodoo.TodoList{
+		Name: listName,
+	}
 	todos.Read()
 	todos.Find(index).MarkAsIncomplete()
 	todos.Save()

--- a/toodoo/todolist.go
+++ b/toodoo/todolist.go
@@ -13,6 +13,7 @@ const todoTemplate = `{{ range .Todos }}[{{ with .Complete }}✔{{ else }} {{ en
 {{ end }}`
 
 type TodoList struct {
+	Name  string
 	Todos []Todo
 }
 
@@ -45,7 +46,7 @@ func newTodo(name string) *Todo {
 }
 
 func (list *TodoList) Read() {
-	file, err := ioutil.ReadFile(saveFileLocation())
+	file, err := ioutil.ReadFile(saveFileLocation(list))
 	todos := new([]Todo)
 	if err == nil {
 		json_err := json.Unmarshal(file, todos)
@@ -63,14 +64,22 @@ func (list *TodoList) Save() {
 		log.Fatal(marshal_err)
 	}
 
-	err := ioutil.WriteFile(saveFileLocation(), buffer, 0644)
+	err := ioutil.WriteFile(saveFileLocation(list), buffer, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
-func saveFileLocation() string {
+func saveFileLocation(list *TodoList) string {
 	usr, _ := user.Current()
 	home_dir := usr.HomeDir
-	return home_dir + "/.toodoos.json"
+	base_dir := home_dir + "/.toodoos"
+	file_path := base_dir + "/" + list.Name + ".json"
+
+	err := os.MkdirAll(base_dir, 0755)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return file_path
 }


### PR DESCRIPTION
All commands now support `--list=<name>` which will call the command on
a different todo list.

This closes #18
